### PR TITLE
silent mode and installation script

### DIFF
--- a/install_wayvibes.sh
+++ b/install_wayvibes.sh
@@ -36,7 +36,7 @@ fi
 
 read -p "Do you want to add auto-start to ~/.profile? (y/n): " PROFILE_CHOICE
 if [[ "$PROFILE_CHOICE" =~ ^[Yy]$ ]]; then
-    CMD="wayvibes \"$SOUNDPACK_PATH\" -v 3 -s"
+    CMD="wayvibes \"$SOUNDPACK_PATH\" -v 3 -bg"
     if ! grep -Fxq "$CMD" ~/.profile; then
         echo "$CMD" >> ~/.profile
         echo "Added to ~/.profile:"

--- a/install_wayvibes.sh
+++ b/install_wayvibes.sh
@@ -1,0 +1,51 @@
+#!/bin/bash
+# filepath: ./install_wayvibes.sh
+
+# Get the directory where this script is located
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+cd "$SCRIPT_DIR"
+
+# Try to find a soundpack directory (first subdir with config.json)
+SOUNDPACK_PATH=""
+for d in "$SCRIPT_DIR"/*/ ; do
+    if [ -f "$d/config.json" ]; then
+        SOUNDPACK_PATH="$d"
+        break
+    fi
+done
+
+if [ -z "$SOUNDPACK_PATH" ]; then
+    echo "Could not find a soundpack directory (with config.json) in $SCRIPT_DIR."
+    read -p "Please enter the full path to your soundpack: " SOUNDPACK_PATH
+fi
+
+echo "Building with make..."
+make
+if [ $? -ne 0 ]; then
+    echo "Build failed."
+    exit 1
+fi
+
+read -p "Do you want to install wayvibes system-wide (sudo make install)? (y/n): " INSTALL_CHOICE
+if [[ "$INSTALL_CHOICE" =~ ^[Yy]$ ]]; then
+    sudo make install
+    echo "wayvibes installed to /usr/local/bin/"
+else
+    echo "You can run it from $SCRIPT_DIR/build/wayvibes or as built by make."
+fi
+
+read -p "Do you want to add auto-start to ~/.profile? (y/n): " PROFILE_CHOICE
+if [[ "$PROFILE_CHOICE" =~ ^[Yy]$ ]]; then
+    CMD="wayvibes \"$SOUNDPACK_PATH\" -v 3 -s"
+    if ! grep -Fxq "$CMD" ~/.profile; then
+        echo "$CMD" >> ~/.profile
+        echo "Added to ~/.profile:"
+        echo "$CMD"
+    else
+        echo "Command already present in ~/.profile"
+    fi
+else
+    echo "Auto-start not added."
+fi
+
+echo "Done."

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -6,11 +6,13 @@
 #include "device.h"
 #include "config.h"
 #include <algorithm>
+#include <unistd.h>
 
 int main(int argc, char *argv[]) {
     std::string soundpackPath = "./";
     float volume = 1.0f;
     std::string configDir;
+    bool silent = false;
     const char *xdgConfigHome = std::getenv("XDG_CONFIG_HOME");
     configDir = (xdgConfigHome ? xdgConfigHome : std::string(getenv("HOME")) + "/.config") + "/wayvibes";
 
@@ -29,25 +31,45 @@ int main(int argc, char *argv[]) {
             } catch (...) {
                 std::cerr << "Invalid volume argument. Using default volume." << std::endl;
             }
+        } else if (std::string(argv[i]) == "--silent" || std::string(argv[i]) == "-s") {
+            silent = true;
         } else if (argv[i][0] != '-') {
             soundpackPath = argv[i];
         }
     }
 
+    if (silent) {
+        pid_t pid = fork();
+        if (pid < 0) {
+            std::cerr << "Failed to fork for silent/background mode." << std::endl;
+            return 1;
+        }
+        if (pid > 0) {
+            // Parent process exits, child continues in background
+            return 0;
+        }
+        // Child process becomes session leader, detaches from terminal
+        setsid();
+        // Optionally redirect stdio to /dev/null
+        freopen("/dev/null", "r", stdin);
+        freopen("/dev/null", "w", stdout);
+        freopen("/dev/null", "w", stderr);
+    }
+
     volume = std::clamp(volume, 0.0f, 10.0f);
 
     if (initializeAudioEngine() != MA_SUCCESS) {
-        std::cerr << "Failed to initialize audio engine" << std::endl;
+        if (!silent) std::cerr << "Failed to initialize audio engine" << std::endl;
         return 1;
     }
 
-    std::cout << "Soundpack: " << soundpackPath << std::endl;
+    if (!silent) std::cout << "Soundpack: " << soundpackPath << std::endl;
     std::unordered_map<int, std::string> keySoundMap = loadKeySoundMappings(soundpackPath + "/config.json");
 
     std::string devicePath = getInputDevicePath(configDir);
 
     if (devicePath.empty()) {
-        std::cout << "No device found. Prompting user." << std::endl;
+        if (!silent) std::cout << "No device found. Prompting user." << std::endl;
         saveInputDevice(configDir);
         devicePath = getInputDevicePath(configDir);
     }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -31,7 +31,7 @@ int main(int argc, char *argv[]) {
             } catch (...) {
                 std::cerr << "Invalid volume argument. Using default volume." << std::endl;
             }
-        } else if (std::string(argv[i]) == "--silent" || std::string(argv[i]) == "-s") {
+        } else if (std::string(argv[i]) == "--background" || std::string(argv[i]) == "-bg") {
             silent = true;
         } else if (argv[i][0] != '-') {
             soundpackPath = argv[i];
@@ -41,7 +41,7 @@ int main(int argc, char *argv[]) {
     if (silent) {
         pid_t pid = fork();
         if (pid < 0) {
-            std::cerr << "Failed to fork for silent/background mode." << std::endl;
+            std::cerr << "Failed to fork for background mode." << std::endl;
             return 1;
         }
         if (pid > 0) {


### PR DESCRIPTION
added silent mode support and installation script for wayvibes

changed files: main.cpp for implement silent mode, when you use the -s flag, now the shell no longer require imput, so now you can add wayvibes to ~./profile without any problems!

added files: install_wayvibes.sh - now it is possibile to build, install and add to ~./profile wayvibes (dependencies required before running it)